### PR TITLE
bug(EJ2-56271): Typo error resolved in getting started For Diagram.

### DIFF
--- a/src/diagrams/diagram/getting-started.md
+++ b/src/diagrams/diagram/getting-started.md
@@ -70,7 +70,7 @@ Import the Component Plugin from the EJ2 Vue Package and register the same using
 Refer the code snippet given below.
 
 ```typescript
-import { DiagramPlugin } from '@syncfuion/ej2-vue-diagrams';
+import { DiagramPlugin } from '@syncfusion/ej2-vue-diagrams';
 
 Vue.use(DiagramPlugin);
 ```


### PR DESCRIPTION
Typo error resolved in getting started For Diagram in Vue. 