### PR TITLE
Update getting-started-vue-3.md

### DIFF
--- a/src/diagrams/diagram/getting-started-vue-3.md
+++ b/src/diagrams/diagram/getting-started-vue-3.md
@@ -41,6 +41,7 @@ In this example, the Diagram component will be used. Use the following command t
 
 ```bash
 npm install @syncfusion/ej2-vue-diagrams --save
+npm install @syncfusion/ej2-vue-dropdowns --save
 ```
 
 ## Adding CSS reference for Syncfusion Vue Diagram component


### PR DESCRIPTION
Because CSS style depends on the `../node_modules/@syncfusion/ej2-vue-dropdowns/styles/material.css`, so we need to install this component.